### PR TITLE
Suppress console logs in tests

### DIFF
--- a/__testHelpers__/setup.js
+++ b/__testHelpers__/setup.js
@@ -1,0 +1,7 @@
+global.console = {
+  log: jest.fn(),
+  error: console.error,
+  warn: console.warn,
+  info: console.info,
+  debug: console.debug
+};

--- a/package.json
+++ b/package.json
@@ -106,6 +106,9 @@
       "node_modules",
       "src/frontend",
       "src/shared"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/__testHelpers__/setup.js"
     ]
   },
   "author": "Jason C. Leach <jason.leach@fullboar.ca>",


### PR DESCRIPTION
Adds a global mock for `console.log` so test outputs aren't as cluttered. Hopefully we can set up better logging at some point with more configuration, but this works as a temporary measure.